### PR TITLE
task_modelのcolumn名を適正化(task_〇〇という表現を削除)

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,14 +2,14 @@
 #
 # Table name: tasks
 #
-#  id               :bigint           not null, primary key
-#  task_description :text             not null
-#  task_name        :string           not null
-#  task_term        :date
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  board_id         :bigint           not null
-#  user_id          :bigint           not null
+#  id          :bigint           not null, primary key
+#  description :text             not null
+#  name        :string           not null
+#  term        :date
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  board_id    :bigint           not null
+#  user_id     :bigint           not null
 #
 # Indexes
 #
@@ -17,8 +17,8 @@
 #  index_tasks_on_user_id   (user_id)
 #
 class Task < ApplicationRecord
-  validates :task_name, presence: true
-  validates :task_description, presence: true
+  validates :name, presence: true
+  validates :description, presence: true
 
   belongs_to :board
   belongs_to :user

--- a/db/migrate/20201019233112_create_tasks.rb
+++ b/db/migrate/20201019233112_create_tasks.rb
@@ -3,9 +3,9 @@ class CreateTasks < ActiveRecord::Migration[6.0]
     create_table :tasks do |t|
       t.references :user, null: false
       t.references :board, null: false
-      t.string :task_name, null: false
-      t.text :task_description, null: false
-      t.date :task_term
+      t.string :name, null: false
+      t.text :description, null: false
+      t.date :term
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -56,9 +56,9 @@ ActiveRecord::Schema.define(version: 2020_10_19_233112) do
   create_table "tasks", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "board_id", null: false
-    t.string "task_name", null: false
-    t.text "task_description", null: false
-    t.date "task_term"
+    t.string "name", null: false
+    t.text "description", null: false
+    t.date "term"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["board_id"], name: "index_tasks_on_board_id"

--- a/test/fixtures/tasks.yml
+++ b/test/fixtures/tasks.yml
@@ -2,14 +2,14 @@
 #
 # Table name: tasks
 #
-#  id               :bigint           not null, primary key
-#  task_description :text             not null
-#  task_name        :string           not null
-#  task_term        :date
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  board_id         :bigint           not null
-#  user_id          :bigint           not null
+#  id          :bigint           not null, primary key
+#  description :text             not null
+#  name        :string           not null
+#  term        :date
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  board_id    :bigint           not null
+#  user_id     :bigint           not null
 #
 # Indexes
 #

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -2,14 +2,14 @@
 #
 # Table name: tasks
 #
-#  id               :bigint           not null, primary key
-#  task_description :text             not null
-#  task_name        :string           not null
-#  task_term        :date
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  board_id         :bigint           not null
-#  user_id          :bigint           not null
+#  id          :bigint           not null, primary key
+#  description :text             not null
+#  name        :string           not null
+#  term        :date
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  board_id    :bigint           not null
+#  user_id     :bigint           not null
 #
 # Indexes
 #


### PR DESCRIPTION
-db:rollbackを行いtask_modelを一旦削除
-task_modelのcolumn名を適正化
-db:migrateを実行
-task.rbのvalidatesを適正化に合わせて変更